### PR TITLE
fix(ci): publish release assets from release workflow

### DIFF
--- a/.github/scripts/release-scripts.test.mjs
+++ b/.github/scripts/release-scripts.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import {
@@ -14,6 +15,15 @@ import {
 	isReleaseRelevantFile,
 	parseManifest,
 } from "./release-utils.mjs";
+
+const releaseWorkflowText = readFileSync(
+	new URL("../workflows/release.yml", import.meta.url),
+	"utf8",
+);
+const releaseAssetsWorkflowText = readFileSync(
+	new URL("../workflows/release-assets.yml", import.meta.url),
+	"utf8",
+);
 
 test("parseManifest reads the package name and version", () => {
 	const manifest = parseManifest(
@@ -188,4 +198,21 @@ test("individual Cargo update helpers reject missing package metadata", () => {
 		),
 		/version = "0\.2\.4"/u,
 	);
+});
+
+test("release workflow delegates asset publishing to the reusable release-assets workflow", () => {
+	assert.match(
+		releaseWorkflowText,
+		/release_assets:[\s\S]*uses:\s+\.\/\.github\/workflows\/release-assets\.yml/u,
+	);
+	assert.match(
+		releaseWorkflowText,
+		/with:[\s\S]*tag:\s+\$\{\{\s*needs\.release\.outputs\.tag\s*\}\}/u,
+	);
+});
+
+test("release-assets workflow is reusable or manually dispatched instead of listening for published releases", () => {
+	assert.match(releaseAssetsWorkflowText, /workflow_call:[\s\S]*tag:/u);
+	assert.match(releaseAssetsWorkflowText, /workflow_dispatch:[\s\S]*tag:/u);
+	assert.doesNotMatch(releaseAssetsWorkflowText, /\n\s*release:\n/u);
 });

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -1,15 +1,24 @@
 name: Release Assets
 
 on:
-  release:
-    types:
-      - published
+  workflow_call:
+    inputs:
+      tag:
+        description: Release tag to build and upload assets for.
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to build and upload assets for.
+        required: true
+        type: string
 
 permissions:
   contents: write
 
 concurrency:
-  group: release-assets-${{ github.event.release.tag_name }}
+  group: release-assets-${{ inputs.tag || github.event.inputs.tag }}
   cancel-in-progress: false
 
 jobs:
@@ -29,7 +38,7 @@ jobs:
       - name: Check out release tag
         uses: actions/checkout@v4.3.1
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ inputs.tag || github.event.inputs.tag }}
 
       - name: Install Rust toolchain
         run: |
@@ -57,7 +66,7 @@ jobs:
 
       - name: Package release assets
         env:
-          TAG: ${{ github.event.release.tag_name }}
+          TAG: ${{ inputs.tag || github.event.inputs.tag }}
           ASSET_SUFFIX: ${{ matrix.asset_suffix }}
         run: |
           package_dir="git-crypt-${TAG}-${ASSET_SUFFIX}"
@@ -70,7 +79,7 @@ jobs:
       - name: Upload release assets
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.event.release.tag_name }}
+          TAG: ${{ inputs.tag || github.event.inputs.tag }}
           ASSET_SUFFIX: ${{ matrix.asset_suffix }}
         run: |
           package_dir="git-crypt-${TAG}-${ASSET_SUFFIX}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,10 @@ jobs:
   release:
     if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
     runs-on: ubuntu-latest
+    outputs:
+      release_needed: ${{ steps.plan.outputs.release_needed }}
+      stable: ${{ steps.release_state.outputs.stable }}
+      tag: ${{ steps.plan.outputs.tag }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GITHUB_REPOSITORY: ${{ github.repository }}
@@ -53,6 +57,15 @@ jobs:
             echo "stable=false" >> "$GITHUB_OUTPUT"
             echo "main advanced during release planning; a later push will handle the release"
           fi
+
+      - name: Record release stability
+        id: release_state
+        run: |
+          stable="${{ steps.stability.outputs.stable }}"
+          if [ -z "$stable" ]; then
+            stable="false"
+          fi
+          echo "stable=$stable" >> "$GITHUB_OUTPUT"
 
       - name: Configure release git identity
         if: steps.plan.outputs.release_needed == 'true' && steps.stability.outputs.stable == 'true'
@@ -93,3 +106,14 @@ jobs:
           gh release create "${{ steps.plan.outputs.tag }}" \
             --title "${{ steps.plan.outputs.tag }}" \
             --generate-notes
+
+  release_assets:
+    name: Release Assets
+    needs: release
+    if: needs.release.outputs.release_needed == 'true' && needs.release.outputs.stable == 'true'
+    permissions:
+      contents: write
+    uses: ./.github/workflows/release-assets.yml
+    secrets: inherit
+    with:
+      tag: ${{ needs.release.outputs.tag }}


### PR DESCRIPTION
## Summary
- call the release-assets workflow from the main release workflow after creating the GitHub release
- convert release-assets into a reusable/manual workflow so it no longer depends on `release.published`
- add regression tests that lock the workflow contract around asset publishing

## Testing
- `node --test .github/hooks/postToolUse/main.test.mjs .github/scripts/*.test.mjs`
- `CONTROL_PLANE_TMP_ROOT=/home/copilot/.copilot/session-state/6c3444a4-eeb9-41e0-9d12-de464e68bab6/files/control-plane-tmp CONTAINERIZED_SCCACHE_IMAGE_CONTEXT=/home/copilot/.copilot/session-state/6c3444a4-eeb9-41e0-9d12-de464e68bab6/files/sccache-image CONTAINERIZED_SCCACHE_IMAGE=localhost/sccache:copilot-fix bash ~/.copilot/skills/containerized-rust-ops/scripts/podman-rust.sh -- sh -ceu 'apt-get update >/dev/null && DEBIAN_FRONTEND=noninteractive apt-get install -y git jq gnupg >/dev/null && cargo test --quiet --locked && ./test.sh'`
